### PR TITLE
Added mapping support for build.author:slackname

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -210,7 +210,13 @@ func (p Plugin) findSlackUser(api *slack.Client) (*slack.User, error) {
 	if val, ok := mapping[p.Build.Email]; ok {
 		logrus.WithFields(logrus.Fields{
 			"username": val,
-		}).Info("Searching for user by name")
+		}).Info("Searching for user by name, using build.email as key")
+		search = checkUsername
+		find = val
+	} else if val, ok := mapping[p.Build.Author]; ok {
+		logrus.WithFields(logrus.Fields{
+			"username": val,
+		}).Info("Searching for user by name, using build.author as key")
 		search = checkUsername
 		find = val
 	} else {


### PR DESCRIPTION
I added another condition that allows mapping the build.author name to the slack name. As far as I have seen it so far, it is only possible to map build.email to the slack name or to map slack email to build.email.

In our case we needed a mapping of Github usernames to slack usernames without specifying the commit email, which is possible with this PR.

So what this PR basically allows you is to use mapping like

```
mapping:
      githubUser: SlackUser
      cbrgm: Chris
     ...
```

I would be happy about a review!

Cheers