### PR TITLE
Comparing email should be case insensitive

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -303,7 +303,7 @@ func contents(s string) string {
 
 // checkEmail sees if the email is used by the user.
 func checkEmail(user *slack.User, email string) bool {
-	return user.Profile.Email == email
+	return strings.EqualFold(user.Profile.Email, email)
 }
 
 // checkUsername sees if the username is the same as the user.


### PR DESCRIPTION
Found a case where slack email addresses were using capitals and thus missing the user.