### PR TITLE
This will use the display name to map users

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -308,5 +308,5 @@ func checkEmail(user *slack.User, email string) bool {
 
 // checkUsername sees if the username is the same as the user.
 func checkUsername(user *slack.User, name string) bool {
-	return user.Name == name
+	return user.Profile.DisplayName == name
 }


### PR DESCRIPTION
This was using the old legacy name on users which is difficult to find in slack. Instead this will use the display name and should fix #30 and #27 

