### PR TITLE
feat: Fall-back to "search for user by display name"

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -219,12 +219,18 @@ func (p Plugin) findSlackUser(api *slack.Client) (*slack.User, error) {
 		}).Info("Searching for user by name, using build.author as key")
 		search = checkUsername
 		find = val
-	} else {
+	} else if p.Build.Email != "" {
 		logrus.WithFields(logrus.Fields{
 			"email": p.Build.Email,
 		}).Info("Searching for user by email")
 		search = checkEmail
 		find = p.Build.Email
+	} else {
+		logrus.WithFields(logrus.Fields{
+			"author": p.Build.Author,
+		}).Info("Searching for user by display name")
+		search = checkUsername
+		find = p.Build.Author
 	}
 
 	if len(find) == 0 {


### PR DESCRIPTION
In case the build email is missing due to too old version of Drone server is being used.

AFAIK, `p.Build.Email` is not set in Drone v0.8.6. I know it is 2 minor versions old compared to the latest release, but this feature breaks nothing while making more users happy :)