### PR TITLE
Support looking up user by real name

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -308,5 +308,5 @@ func checkEmail(user *slack.User, email string) bool {
 
 // checkUsername sees if the username is the same as the user.
 func checkUsername(user *slack.User, name string) bool {
-	return user.Profile.DisplayName == name
+	return user.Profile.DisplayName == name || user.RealName == name
 }


### PR DESCRIPTION
Setting a display name in Slack is optional, while the real name is required. In my case this meant having to ask multiple coworkers to create a display name so I could include them in the mapping, which can be avoided if user's can be looked up by their real name as well. This is also more maintainable, as people are more likely to change their display name.