### PR TITLE
Make this plugin compatible with drone kubernetes runner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/drone-plugins/drone-slack-blame
 
 require (
 	github.com/drone/drone-template-lib v1.0.0
+	github.com/joho/godotenv v1.5.1
 	github.com/nlopes/slack v0.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
 github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -177,6 +178,10 @@ func main() {
 			Usage:  "previous build sha",
 			EnvVar: "DRONE_PREV_COMMIT_SHA",
 		},
+	}
+
+	if _, err := os.Stat("/run/drone/env"); err == nil {
+		godotenv.Overload("/run/drone/env")
 	}
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Problem best described [here](https://docs.drone.io/runner/kubernetes/overview/) under Known Issues.
> Unlike docker pipelines, the pipeline status is passed to steps by file as opposed to environment variable. Existing plugins may not be compatible with kubernetes pipelines and will need to be patched accordingly. See [how we patched](https://github.com/drone-plugins/drone-slack/commit/cb7ba0bbbaff73c8c14f28431c0ff2866368ef50) the Slack plugin.


Implemented referencing the example in documentation:
https://github.com/drone-plugins/drone-slack/commit/cb7ba0bbbaff73c8c14f28431c0ff2866368ef50